### PR TITLE
Support unbundled version of fmt in spdlog

### DIFF
--- a/include/spdmon/spdmon.hpp
+++ b/include/spdmon/spdmon.hpp
@@ -690,6 +690,7 @@ namespace spdmon
         ~LoggerProgress()
         {
             spdlog::set_default_logger(default_logger_);
+            spdlog::drop(custom_logger_->name());
         };
 
         SPDMON_DECLARE_NON_COPYABLE(LoggerProgress)

--- a/include/spdmon/spdmon.hpp
+++ b/include/spdmon/spdmon.hpp
@@ -6,7 +6,7 @@
 #include <atomic>
 #include <iostream>
 
-#include <spdlog/fmt/bundled/chrono.h>
+#include <spdlog/fmt/chrono.h>
 #include <spdlog/common.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/details/console_globals.h>

--- a/include/spdmon/spdmon.hpp
+++ b/include/spdmon/spdmon.hpp
@@ -221,7 +221,7 @@ namespace spdmon
                            fmt::arg("remaining", remaining),
                            fmt::arg("eol", kTermEol));
 
-            const auto space_for_bar = static_cast<unsigned int>(width - buf.size() - right.size() + kTermEol.size());
+            const auto space_for_bar = static_cast<int>(width - buf.size() - right.size() + kTermEol.size());
             if (space_for_bar > 0)
             {
                 FormatBarTo(buf, space_for_bar, frac);

--- a/include/spdmon/spdmon.hpp
+++ b/include/spdmon/spdmon.hpp
@@ -139,7 +139,7 @@ namespace spdmon
             }
 
             buf.reserve(buf.size() + width * 3);
-            auto it = std::back_inserter(buf);
+            auto it = fmt::appender(buf);
 
             const auto complete = static_cast<unsigned int>(frac * static_cast<float>(width * nsyms_));
             const size_t full_blocks = complete / nsyms_;
@@ -198,7 +198,7 @@ namespace spdmon
 
             if (total_ == 0)
             {
-                fmt::format_to(buf, kNoTotalFmt, fmt::arg("desc", desc_),
+                fmt::format_to(fmt::appender(buf), kNoTotalFmt, fmt::arg("desc", desc_),
                                fmt::arg("n", n_),
                                fmt::arg("elapsed", elapsed),
                                fmt::arg("eol", kTermEol));
@@ -213,13 +213,13 @@ namespace spdmon
 
             const float percent = frac * 100;
 
-            fmt::format_to(buf, kLbarFmt, fmt::arg("desc", desc_),
-                           fmt::arg("frac", percent));
-            fmt::format_to(right, kRbarFmt, fmt::arg("n", n_),
-                           fmt::arg("total", total_),
-                           fmt::arg("elapsed", elapsed),
-                           fmt::arg("remaining", remaining),
-                           fmt::arg("eol", kTermEol));
+            fmt::format_to(fmt::appender(buf), kLbarFmt, fmt::arg("desc", desc_),
+                          fmt::arg("frac", percent));
+            fmt::format_to(fmt::appender(right), kRbarFmt, fmt::arg("n", n_),
+                          fmt::arg("total", total_),
+                          fmt::arg("elapsed", elapsed),
+                          fmt::arg("remaining", remaining),
+                          fmt::arg("eol", kTermEol));
 
             const auto space_for_bar = static_cast<int>(width - buf.size() - right.size() + kTermEol.size());
             if (space_for_bar > 0)


### PR DESCRIPTION
This change includes `spdlog/fmt/chrono.h`  instead of `spdlog/fmt/bundled/chrono.h`, which will include the correct version of fmt depending on if it was bundled with spdlog or not.

Furthermore, the `fmt::memory_buffer` now seems to need to be used with the `fmt::appender` and can not be passed directly to `format_to`.

Lastly, the variable `space_for_bar` is cast to an `int` instead of an `unsigned int`, as otherwise, the following size check would always return true. In cases where the width is not sufficient, it would then try to fill a progress bar with a width close to max `unsigned int` due to an integer underflow. 